### PR TITLE
Update filename pattern to '*' to aid in associating geff files

### DIFF
--- a/src/napari_geff/napari.yaml
+++ b/src/napari_geff/napari.yaml
@@ -18,7 +18,7 @@ contributions:
   readers:
     - command: napari-geff.get_reader
       accepts_directories: true
-      filename_patterns: ['*.zarr']
+      filename_patterns: ['*']
   writers:
     - command: napari-geff.write_multiple
       layer_types: ['image*','labels*']


### PR DESCRIPTION
# Description
In napari you can associate filename patterns with certain readers, but this is trickier for folders. Our current pattern of `.zarr` essentially forbids you from making an association for geff files, since the folders don't end in `.zarr`. This PR relaxes the pattern to `*`, so that associations can be made.

Note that we should also look at addressing [npe2/#155](https://github.com/napari/npe2/issues/155) so that a better filename pattern can be specified if the geff spec is updated (see [geff/#126](https://github.com/live-image-tracking-tools/geff/issues/126)) to give us a meaningful filename signifier.