### PR TITLE
Be able to access the edge metadata from the tracks layer metadata 

### DIFF
--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -101,7 +101,11 @@ def reader_function(
     tracks_napari = node_data_df[
         ["track_id", "t"] + list(nx_graph.graph.get("axis_names", []))
     ]
-    metadata = {"nx_graph": nx_graph}
+
+    metadata = {
+        "nx_graph": nx_graph,
+        "edge_properties": nx.to_pandas_edgelist(nx_graph),
+    }
     return [
         (
             tracks_napari,

--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -53,8 +53,8 @@ def get_geff_reader(path: Union[str, list[str]]) -> Callable | None:
 
     # graph attrs validation
     # Raises pydantic.ValidationError or ValueError
-    meta = GeffMetadata(**graph.attrs)
-    if meta.position_attr is None and meta.axis_names is None:
+    meta = GeffMetadata(**graph.attrs["geff"])
+    if meta.position_prop is None and meta.axis_names is None:
         return None
     if not meta.directed:
         return None


### PR DESCRIPTION
# Description
I'm just passing the edge list, with corresponding edge attribute columns (if any) to the metadata dict to expose them to the writer. 
