### PR TITLE
Respect display hints when determining axis ordering

### DIFF
--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -121,21 +121,30 @@ def reader_function(
 
     # if display hints are provided, we make sure our spatial axis names
     # are ordered accordingly
+    display_axis_dict = {}
     if geff_metadata.display_hints:
-        spatial_axes_names = []
         display_hints = geff_metadata.display_hints
         if display_hints.display_depth:
-            spatial_axes_names.append(display_hints.display_depth)
+            display_axis_dict["depth"] = display_hints.display_depth
         if display_hints.display_vertical:
-            spatial_axes_names.append(display_hints.display_vertical)
+            display_axis_dict["vertical"] = display_hints.display_vertical
         if display_hints.display_horizontal:
-            spatial_axes_names.append(display_hints.display_horizontal)
+            display_axis_dict["horizontal"] = display_hints.display_horizontal
+    display_axes = []
+    for axis_type in ["depth", "vertical", "horizontal"]:
+        if axis_type in display_axis_dict:
+            display_axes.append(display_axis_dict[axis_type])
+            spatial_axes_names.remove(display_axis_dict[axis_type])
+    display_axes = spatial_axes_names + display_axes
+    # we cannot have more than 3 display axes, so we grab the last three if needed
+    if len(display_axes) > 3:
+        display_axes = display_axes[-3:]
 
     tracks_napari = node_data_df[
         (
             ["napari_track_id"]
             + ([time_axis_name] if time_axis_name else [])
-            + spatial_axes_names
+            + display_axes
         )
     ]
     tracks_napari.sort_values(

--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -119,6 +119,18 @@ def reader_function(
         elif axis.type == "space":
             spatial_axes_names.append(axis.name)
 
+    # if display hints are provided, we make sure our spatial axis names
+    # are ordered accordingly
+    if geff_metadata.display_hints:
+        spatial_axes_names = []
+        display_hints = geff_metadata.display_hints
+        if display_hints.display_depth:
+            spatial_axes_names.append(display_hints.display_depth)
+        if display_hints.display_vertical:
+            spatial_axes_names.append(display_hints.display_vertical)
+        if display_hints.display_horizontal:
+            spatial_axes_names.append(display_hints.display_horizontal)
+
     tracks_napari = node_data_df[
         (
             ["napari_track_id"]

--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -47,7 +47,7 @@ def get_geff_reader(path: Union[str, list[str]]) -> Callable | None:
 
     try:
         validate(path)
-    except (AssertionError, pydantic.ValidationError):
+    except (AssertionError, pydantic.ValidationError, ValueError):
         return None
 
     graph = zarr.open(path, mode="r")

--- a/src/napari_geff/_tests/conftest.py
+++ b/src/napari_geff/_tests/conftest.py
@@ -7,6 +7,7 @@ import networkx as nx
 import numpy as np
 import pytest
 from numpy.typing import NDArray
+from typing_extensions import NotRequired
 
 DTypeStr = Literal[
     "double",
@@ -22,6 +23,12 @@ DTypeStr = Literal[
 Axes = Literal["t", "z", "y", "x"]
 
 
+class DesignHints(TypedDict):
+    display_vertical: NotRequired[str]
+    display_horizontal: NotRequired[str]
+    display_depth: NotRequired[str]
+
+
 class GraphAttrs(TypedDict):
     nodes: NDArray[Any]
     edges: NDArray[Any]
@@ -35,6 +42,7 @@ class GraphAttrs(TypedDict):
     axis_names: tuple[Axes, ...]
     axis_units: tuple[str, ...]
     axis_types: tuple[str, ...]  # Added for type declaration
+    design_hints: NotRequired[DesignHints]
 
 
 class ExampleNodeProps(TypedDict):
@@ -54,7 +62,7 @@ def create_dummy_graph_props(
 ) -> GraphAttrs:
     """Creates a dictionary of graph properties for testing."""
     axis_names: tuple[Axes, ...] = ("t", "z", "y", "x")
-    axis_units = ("s", "nm", "nm", "nm")
+    axis_units = ("second", "nanometer", "nanometer", "nanometer")
     axis_types = ("time", "space", "space", "space")  # Added axis types
 
     nodes = np.array([10, 2, 127, 4, 5], dtype=node_dtype)
@@ -81,7 +89,7 @@ def create_dummy_graph_props(
         "directed": directed,
         "axis_names": axis_names,
         "axis_units": axis_units,
-        "axis_types": axis_types,  # Added to returned dict
+        "axis_types": axis_types,  # Added to returned dict,
     }
 
 

--- a/src/napari_geff/_tests/test_reader.py
+++ b/src/napari_geff/_tests/test_reader.py
@@ -148,9 +148,8 @@ def test_reader_loads_attrs(path_w_expected_graph_props):
     assert all((True for _, item in edge_meta.items() if "color" in item))
 
 
-def test_get_display_axes():
-    """Test that the display axes are correctly set"""
-
+def test_display_axes_no_hints_all_provided():
+    """Test that the display axes are correct when no display hints are provided."""
     # no display hints provided
     props = {}
     props["axes"] = [
@@ -165,6 +164,10 @@ def test_get_display_axes():
     assert display_axes == ["t", "z", "y", "x"]
     assert time_axis == "t"
 
+
+def test_display_axes_no_hints_additional_spatial_axes_respects_time():
+    """Test that display axes are correct with no display hints, time available, and additional spatial axes."""
+    props = {}
     # no display hints and more than 4 spatiotemporal axes
     # innermost spatial axes returned, but time is always included
     props["axes"] = [
@@ -174,12 +177,16 @@ def test_get_display_axes():
         Axis(type="space", name="y"),
         Axis(type="space", name="x"),
     ]
+    props["display_hints"] = None
     props_dot = SimpleNamespace(**props)
     display_axes, time_axis = get_display_axes(props_dot)
     assert display_axes == ["t", "c", "y", "x"]
     assert time_axis == "t"
 
-    # no display hints, more than 4 spatial axes, no time
+
+def test_display_axes_no_hints_no_time():
+    """Test that display axes are correct with no display hints and no time axis."""
+    props = {}
     props["axes"] = [
         Axis(type="space", name="other"),
         Axis(type="space", name="z"),
@@ -187,12 +194,16 @@ def test_get_display_axes():
         Axis(type="space", name="y"),
         Axis(type="space", name="x"),
     ]
+    props["display_hints"] = None
     props_dot = SimpleNamespace(**props)
     display_axes, time_axis = get_display_axes(props_dot)
     assert display_axes == ["z", "c", "y", "x"]
     assert time_axis is None
 
-    # full display hints, order is respected
+
+def test_display_axes_full_hints():
+    """Test that display axes are correctly ordered with full display hints provided."""
+    props = {}
     props["display_hints"] = DisplayHint(
         display_vertical="z", display_horizontal="y", display_depth="x"
     )
@@ -206,10 +217,20 @@ def test_get_display_axes():
     display_axes, time_axis = get_display_axes(props_dot)
     assert display_axes == ["t", "x", "z", "y"]
 
-    # fewer display hints than space axes, order is respected
+
+def test_display_axes_partial_hints():
+    """Test that display axes are correctly ordered with partial display hints provided."""
+    # fewer display hints than space axes, given axis order is respected
+    props = {}
     props["display_hints"] = DisplayHint(
         display_vertical="z", display_horizontal="y"
     )
+    props["axes"] = [
+        Axis(type="time", name="t"),
+        Axis(type="space", name="z"),
+        Axis(type="space", name="y"),
+        Axis(type="space", name="x"),
+    ]
     props_dot = SimpleNamespace(**props)
     display_axes, time_axis = get_display_axes(props_dot)
     assert display_axes == ["t", "x", "z", "y"]

--- a/src/napari_geff/utils.py
+++ b/src/napari_geff/utils.py
@@ -52,7 +52,7 @@ def diff_nx_graphs(
             val1, val2 = attrs1.get(key), attrs2.get(key)
 
             # Check for difference in value, and optionally type
-            type_mismatch = check_types and type(val1) != type(val2)
+            type_mismatch = check_types and type(val1) is not type(val2)
             if val1 != val2 or type_mismatch:
                 type1_str = type(val1).__name__ if key in attrs1 else "N/A"
                 type2_str = type(val2).__name__ if key in attrs2 else "N/A"
@@ -114,7 +114,7 @@ def diff_nx_graphs(
             val1, val2 = attrs1.get(key), attrs2.get(key)
 
             # Check for difference in value, and optionally type
-            type_mismatch = check_types and type(val1) != type(val2)
+            type_mismatch = check_types and type(val1) is not type(val2)
             if val1 != val2 or type_mismatch:
                 type1_str = type(val1).__name__ if key in attrs1 else "N/A"
                 type2_str = type(val2).__name__ if key in attrs2 else "N/A"


### PR DESCRIPTION
# Description
This PR parses the `GeffMetadata.display_hints` property, when available, to ensure axis ordering is determined correctly according to the spec.

When full display hints are available, the axis ordering is fully determined. We **always** take the defined time axis as the outermost dimension (regardless of the `display_time` hint).

When more spatial axes than display hints are defined, we populate display axes with additional spatial axes in order of their definition in the spec.

We never select more than 4 display axes (1 time + 3 spatial, if time is available OR 4 spatial if no time is available). 
