### PR TITLE
Pin geff to 0.4.0 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "magicgui",
     "qtpy",
     "scikit-image",
-    "geff@git+https://github.com/live-image-tracking-tools/geff",
+    "geff==0.4.0",
     "pandas",
 ]
 


### PR DESCRIPTION
# Description
For the initial napari-geff release we want to pin geff to 0.4.0 (trackathon latest) to ensure we have a working package. Once future versions are released we will make sure to update napari-geff to match latest spec
