### PR TITLE
Do not try to convert non simple dtypes

### DIFF
--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -8,6 +8,7 @@ The original networkx graph read by `geff.read_nx` is stored in the metadata
 attribute on the layer.
 """
 
+import contextlib
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -177,12 +178,10 @@ def reader_function(
     }
     for prop in zarrgeff["nodes"]["props"]:
         dtype = zarrgeff["nodes"]["props"][prop]["values"].dtype
-        if dtype in np_to_pd_dtype:
+        with contextlib.suppress(ValueError, TypeError):
             node_data_df[prop] = node_data_df[prop].astype(
                 np_to_pd_dtype[dtype]
             )
-        else:
-            pass
 
     layers += [
         (


### PR DESCRIPTION
Some geffs, such as those from Trackastra have a coords property which is a tuple, and these would get caught and error out when trying to preserve their type. 