### PR TITLE
Fix/tracks layer offset param

### DIFF
--- a/src/napari_geff/_reader.py
+++ b/src/napari_geff/_reader.py
@@ -129,7 +129,7 @@ def reader_function(
                             {
                                 "name": "Labels",
                                 "scale": scale,
-                                "offset": offset,
+                                "translate": offset,
                             },
                             "labels",
                         )
@@ -144,7 +144,7 @@ def reader_function(
                             {
                                 "name": "Image",
                                 "scale": scale,
-                                "offset": offset,
+                                "translate": offset,
                             },
                             "image",
                         )
@@ -212,7 +212,7 @@ def reader_function(
                 "metadata": metadata,
                 "features": node_data_df,
                 "scale": scale,
-                "offset": offset,
+                "translate": offset,
             },
             "tracks",
         )

--- a/src/napari_geff/_tests/test_reader.py
+++ b/src/napari_geff/_tests/test_reader.py
@@ -1,6 +1,7 @@
 import json
 from types import SimpleNamespace
 
+import napari
 import numpy as np
 import pandas as pd
 import zarr
@@ -117,7 +118,7 @@ def test_reader_geff_no_space_axes(tmp_path, path_w_expected_graph_props):
 
 
 def test_reader_loads_layer(path_w_expected_graph_props):
-    """Test the reader returns a tracks layer"""
+    """Test the reader returns a tracks layer that is readable by the napari Viewer."""
     written_path, props = path_w_expected_graph_props(
         np.uint16,
         {"position": "double"},
@@ -126,11 +127,14 @@ def test_reader_loads_layer(path_w_expected_graph_props):
     )
     layer_tuples = reader_function(str(written_path))
     assert len(layer_tuples) == 1
-    layer_tuple = layer_tuples[0]
-    assert len(layer_tuple) == 3
-    assert isinstance(layer_tuple[0], pd.DataFrame)
-    assert isinstance(layer_tuple[1], dict)
-    assert layer_tuple[2] == "tracks"
+    data, metadata, layer_type = layer_tuples[0]
+    assert isinstance(data, pd.DataFrame)
+    assert isinstance(metadata, dict)
+    assert layer_type == "tracks"
+
+    viewer = napari.Viewer()
+    viewer.add_tracks(data, **metadata)
+    viewer.close()
 
 
 # TODO: update once test fixture writes out some node properties


### PR DESCRIPTION
This fixes the vocabulary for passing the offset newly supported in GEFF to napari layers, and extends reader testing to an end-to-end scenario.